### PR TITLE
Fix valgrind warning

### DIFF
--- a/src/liblogfaf.c
+++ b/src/liblogfaf.c
@@ -170,6 +170,7 @@ __attribute__((destructor)) static void _liblogfaf_fini(void) {
         fprintf(stderr, "liblogfaf: pthread_mutex_destroy() failed\n");
         exit(1);
     }
+    freeaddrinfo(shared_data.serveraddr);
 }
 
 void openlog(const char *ident, int option, int facility) {


### PR DESCRIPTION
Valgrind warns about shared_data.serveraddr memory leak. It doesn't need to be freed, but it seems that there is no downside of calling extra freeaddrinfo(), and it's easier to free it than adding a suppression file for the leak.
