### PR TITLE
Allow binding socker to an IP

### DIFF
--- a/src/logfaf.in
+++ b/src/logfaf.in
@@ -10,13 +10,14 @@
 set -e -u
 
 help() {
-    >&2 echo "Usage: ${0##*/} [-h] [-S servername] [-P port] <command>"
+    >&2 echo "Usage: ${0##*/} [-h] [-S servername] [-P port] [-B ip] <command>"
     >&2 echo " -h                show help"
     >&2 echo " -S servername     set syslog server name (default: localhost)"
     >&2 echo " -P port           set syslog port (default: 514)"
+    >&2 echo " -B ip             bind to ip (default: no binding)"
 }
 
-while getopts :hS:P: OPT; do
+while getopts :hS:P:B: OPT; do
     case ${OPT} in
         h)
         help
@@ -29,6 +30,10 @@ while getopts :hS:P: OPT; do
 
         P)
         export LIBLOGFAF_PORT=${OPTARG}
+        ;;
+
+        B)
+        export LIBLOGFAF_BIND_IP=${OPTARG}
         ;;
 
         \?)


### PR DESCRIPTION
UDP socket will bind to a random port on any addresses. This allow
specifying the IP to bind the socket to in order to avoid port clashes
and/or enforce the outgoing IP address used by the syslog packets.